### PR TITLE
Switch names of `parse_query` etc to camelCase

### DIFF
--- a/include/VNNLib.h
+++ b/include/VNNLib.h
@@ -17,8 +17,8 @@
 
 #include "Error.hpp"
 
-VNNLIB_API std::unique_ptr<TQuery> parse_query_file(std::string path);
-VNNLIB_API std::unique_ptr<TQuery> parse_query_string(std::string content);
-VNNLIB_API std::string check_query_file(std::string path);
-VNNLIB_API std::string check_query_string(std::string content);
+VNNLIB_API std::unique_ptr<TQuery> parseQueryFile(std::string path);
+VNNLIB_API std::unique_ptr<TQuery> parseQueryString(std::string content);
+VNNLIB_API std::string checkQueryFile(std::string path);
+VNNLIB_API std::string checkQueryString(std::string content);
 

--- a/src/VNNLib.cpp
+++ b/src/VNNLib.cpp
@@ -3,7 +3,7 @@
 // Forward declaration
 extern Query* psQuery(const char *str);
 
-std::unique_ptr<TQuery> parse_query_file(std::string path) {
+std::unique_ptr<TQuery> parseQueryFile(std::string path) {
     FILE *file = fopen(path.c_str(), "r");
     if (!file) {
         std::fprintf(stderr, "Error: Cannot open input file '%s': %s\n", path.c_str(), std::strerror(errno));
@@ -34,7 +34,7 @@ std::unique_ptr<TQuery> parse_query_file(std::string path) {
     return typed;
 }
 
-std::unique_ptr<TQuery> parse_query_string(std::string content) {
+std::unique_ptr<TQuery> parseQueryString(std::string content) {
     VNNLibQuery *parse_tree = nullptr;
     try {
         Query *query = psQuery(content.c_str());
@@ -57,7 +57,7 @@ std::unique_ptr<TQuery> parse_query_string(std::string content) {
     return typed;
 }
 
-std::string check_query_file(std::string path) {
+std::string checkQueryFile(std::string path) {
     FILE *file = fopen(path.c_str(), "r");
     if (!file) {
         std::fprintf(stderr, "Error: Cannot open input file '%s': %s\n", path.c_str(), std::strerror(errno));
@@ -86,7 +86,7 @@ std::string check_query_file(std::string path) {
     return "";
 }
 
-std::string check_query_string(std::string content) {
+std::string checkQueryString(std::string content) {
     VNNLibQuery *parse_tree = nullptr;
     try {
         Query *query = psQuery(content.c_str());

--- a/src/VNNLibJulia.cpp
+++ b/src/VNNLibJulia.cpp
@@ -136,24 +136,24 @@ TDataType to_cpp_type_enum(JuliaDType jdt) {
     }
 }
 
-// Return a shared_ptr<TQuery> by converting the unique_ptr returned by parse_query_file
+// Return a shared_ptr<TQuery> by converting the unique_ptr returned by parseQueryFile
 std::shared_ptr<TQuery> jl_parse_query_file(const std::string& path) {
-    return parse_query_file(path);
+    return parseQueryFile(path);
 }
 
-// parse_query_string: return shared_ptr<TQuery> by converting the unique_ptr
+// parseQueryString: return shared_ptr<TQuery> by converting the unique_ptr
 std::shared_ptr<TQuery> jl_parse_query_string(const std::string& content) {
-    return parse_query_string(content);
+    return parseQueryString(content);
 }
 
-// check_query_file: returns result string
+// checkQueryFile: returns result string
 std::string jl_check_query_file(const std::string& path) {
-    return check_query_file(path);
+    return checkQueryFile(path);
 }
 
-// check_query_string: returns result string
+// checkQueryString: returns result string
 std::string jl_check_query_string(const std::string& content) {
-    return check_query_string(content);
+    return checkQueryString(content);
 }
 
 std::vector<const TNode *> jl_children_sp(const TNode& node) {
@@ -1131,10 +1131,10 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {
             return out;
         });
     // Existing methods
-    mod.method("parse_query_file", &jl_parse_query_file);
-    mod.method("parse_query_string", &jl_parse_query_string);
-    mod.method("check_query_file", &jl_check_query_file);
-    mod.method("check_query_string", &jl_check_query_string);
+    mod.method("parseQueryFile", &jl_parse_query_file);
+    mod.method("parseQueryString", &jl_parse_query_string);
+    mod.method("checkQueryFile", &jl_check_query_file);
+    mod.method("checkQueryString", &jl_check_query_string);
     mod.method("transform_to_compat", [](const TQuery& q) {
         CompatTransformer transformer(&q);
         return transformer.transform();


### PR DESCRIPTION
I messed this up the first time, apologies. @samysweb I've left the Julia bindings using snakecase as I'm not sure what the Julia convention is.