### PR TITLE
Accept lowercase real element type

### DIFF
--- a/src/TypeChecker.cpp
+++ b/src/TypeChecker.cpp
@@ -6,7 +6,7 @@
 TDataType TypeChecker::mapDType(ElementType* e) {
     DType *dt = dynamic_cast<DType *>(e);
     std::string typeName = dt->variablename_->string_;
-    if (typeName == "real" || typeName == "Real") return TDataType::Real;
+    if (typeName == "real") return TDataType::Real;
     else if (typeName == "float16") return TDataType::F16;
     else if (typeName == "float32") return TDataType::F32;
     else if (typeName == "float64") return TDataType::F64;

--- a/src/TypeChecker.cpp
+++ b/src/TypeChecker.cpp
@@ -6,7 +6,7 @@
 TDataType TypeChecker::mapDType(ElementType* e) {
     DType *dt = dynamic_cast<DType *>(e);
     std::string typeName = dt->variablename_->string_;
-    if (typeName == "Real") return TDataType::Real;
+    if (typeName == "real" || typeName == "Real") return TDataType::Real;
     else if (typeName == "float16") return TDataType::F16;
     else if (typeName == "float32") return TDataType::F32;
     else if (typeName == "float64") return TDataType::F64;


### PR DESCRIPTION
## Summary

This PR updates the type checker to recognize lowercase `real` as the real-valued element type.

The VNN-LIB standard specifies the real network theory element type as lowercase `real`, but the current implementation only maps uppercase `Real` to `TDataType::Real`. As a result, valid VNN-LIB 2.0 files using `real` are parsed but then type checked with variables of type `Unknown`.

This change accepts the standard lowercase spelling while preserving existing compatibility with uppercase `Real`.

## Example

The following valid VNN-LIB 2.0 query currently fails type checking because `real` is mapped to `Unknown`:

```lisp
(vnnlib-version <2.0>)
(declare-network f
  (declare-input X real [1])
  (declare-output Y real [1])
)
(assert (<= (* X[0] 2.0) Y[0]))